### PR TITLE
Cut from ReasonReact representation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ Then add `reason-react-compat` to your `bsconfig.json` `bs-dependencies` field.
 Enables you to wrap your existing `ReasonReact.statelessComponent` and `ReasonReact.reducerComponent` through a React hook.
 
 ```reason
-let component = ReasonReact.statelessComponent("MyComponent");
-
 [@react.component]
 let make = () => {
   ReactCompat.useRecordApi({
-    ...component,
+    ...ReactCompat.component,
     render: _ =>
       <div> "Helloworld!"->ReasonReact.string </div>
   })
@@ -40,14 +38,15 @@ let make = () => {
 For implementation files (`.re`)
 
 ```diff
- let component = ReasonReact.statelessComponent("MyComponent");
+-let component = ReasonReact.statelessComponent("MyComponent");
 
 +[@react.component]
 - let make = _ => {
 + let make = () => {
 +  ReactCompat.useRecordApi(
      {
-       ...component,
+-      ...component,
++      ...ReactCompat.component,
        render: _ =>
          <div> "Helloworld!"->ReasonReact.string </div>
      }
@@ -60,7 +59,7 @@ For interface files (`.rei`)
 ```diff
 
 +[@react.component]
-- let make = _ =>
+- let make = 'a =>
 + let make = unit =>
 -  ReasonReact.component(
 -    ReasonReact.stateless,
@@ -79,14 +78,15 @@ For implementation files (`.re`)
 
  type state = {count: int};
 
- let component = ReasonReact.reducerComponent("MyComponent");
+-let component = ReasonReact.reducerComponent("MyComponent");
 
 +[@react.component]
 - let make = _ => {
 + let make = () => {
 +  ReactCompat.useRecordApi(
      {
-       ...component,
+-      ...component,
++      ...ReactCompat.component,
        /* some lifecycle */
        render: _ =>
          <div> "Helloworld!"->ReasonReact.string </div>
@@ -94,6 +94,13 @@ For implementation files (`.re`)
 +  )
  }
 ```
+
+You'll also need to rename:
+
+- `ReasonReact.Update` -> `Update`
+- `ReasonReact.UpdateWithSideEffects` -> `UpdateWithSideEffects`
+- `ReasonReact.SideEffects` -> `SideEffects`
+- `ReasonReact.NoUpdate` -> `NoUpdate`
 
 For interface files (`.rei`)
 
@@ -103,7 +110,7 @@ For interface files (`.rei`)
 -type action;
 
 +[@react.component]
-- let make = _ =>
+- let make = 'a =>
 + let make = unit =>
 -  ReasonReact.component(
 -    state,

--- a/src/ReactCompat.re
+++ b/src/ReactCompat.re
@@ -84,6 +84,8 @@ let useRecordApi = componentSpec => {
       Js.Array.push(sideEffect, unmountSideEffects->current)->ignore,
   };
 
+  let upToDateSelf = React.useRef(self);
+
   let hasBeenCalled = React.useRef(false);
 
   /** There might be some potential issues with willReceiveProps,
@@ -91,8 +93,8 @@ let useRecordApi = componentSpec => {
   state :=
     componentSpec.willReceiveProps(self);
 
-  let rec self = {
-    handle: (fn, payload) => fn(payload, self),
+  let self = {
+    handle: (fn, payload) => fn(payload, upToDateSelf->current),
     send,
     state: state^,
     onUnmount: sideEffect =>
@@ -142,6 +144,8 @@ let useRecordApi = componentSpec => {
 
   let mostRecentAllowedRender =
     React.useRef(React.useMemo0(() => componentSpec.render(self)));
+
+  upToDateSelf->setCurrent(self);
 
   if (hasBeenCalled->current
       && componentSpec.shouldUpdate({

--- a/src/ReactCompat.re
+++ b/src/ReactCompat.re
@@ -180,3 +180,10 @@ let component: component('state, 'initialState, 'action) = {
   initialState: Defaults.initialStateDefault,
   reducer: Defaults.reducerDefault,
 };
+
+let useMount = func => {
+  React.useEffect0(() => {
+    func();
+    None;
+  });
+};

--- a/src/ReactCompat.rei
+++ b/src/ReactCompat.rei
@@ -1,0 +1,33 @@
+type component('state, 'initialState, 'action) = {
+  willReceiveProps: self('state, 'action) => 'state,
+  willUnmount: self('state, 'action) => unit,
+  didUpdate: oldNewSelf('state, 'action) => unit,
+  shouldUpdate: oldNewSelf('state, 'action) => bool,
+  willUpdate: oldNewSelf('state, 'action) => unit,
+  didMount: self('state, 'action) => unit,
+  initialState: unit => 'initialState,
+  reducer: ('action, 'state) => update('state, 'action),
+  render: self('state, 'action) => React.element,
+}
+and update('state, 'action) =
+  | NoUpdate
+  | Update('state)
+  | SideEffects(self('state, 'action) => unit)
+  | UpdateWithSideEffects('state, self('state, 'action) => unit)
+and self('state, 'action) = {
+  handle:
+    'payload.
+    (('payload, self('state, 'action)) => unit, 'payload) => unit,
+
+  state: 'state,
+  send: 'action => unit,
+  onUnmount: (unit => unit) => unit,
+}
+and oldNewSelf('state, 'action) = {
+  oldSelf: self('state, 'action),
+  newSelf: self('state, 'action),
+};
+
+let useRecordApi: component('state, 'state, 'action) => React.element;
+
+let component: component('state, unit, 'action);

--- a/src/ReactCompat.rei
+++ b/src/ReactCompat.rei
@@ -31,3 +31,5 @@ and oldNewSelf('state, 'action) = {
 let useRecordApi: component('state, 'state, 'action) => React.element;
 
 let component: component('state, unit, 'action);
+
+let useMount: (unit => unit) => unit;


### PR DESCRIPTION
The main motivation here is to remove the need to import the legacy ReasonReact module, which brings some runtime and code that become unnecessary after migrating.

I'm going to update the https://github.com/bloodyowl/upgrade-reason-react-esy upgrade path with an option that removes the "let component" factories in favor of a shared ReactCompat variable, in order to simplify the process. The type safety is ensured at the 'useRecordApi' API level, by specifying the "component('state, 'state, 'action)" parameter type (binding initialState and state together).

I've taken the occasion to remove anything related to retainedProps, which I didn't see anybody using for a while now.

This copies some type declarations from the legacy ReasonReact API and removes some key that aren't necessary anymore. The keys also have been sorted from least to most used (just what I observed in an internal codebase, it might not be the case everywhere), this will help compression algorithms like gzip and brotli.